### PR TITLE
Simplify unified pipeline frame execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ dynamic_shapes = true           # 동적 크기 지원
 UnifiedGraphPipeline pipeline(config);
 pipeline.initialize();
 
-// 비동기 실행
-pipeline.executeGraphNonBlocking(stream);
+// 프레임 실행
+pipeline.executeFrame(stream);
 
 // 결과 획득
 Target* targets = pipeline.getTargets();
@@ -496,8 +496,7 @@ TEST(PipelineTest, InferenceLatency) {
     UnifiedGraphPipeline pipeline(testConfig);
     
     auto start = std::chrono::high_resolution_clock::now();
-    pipeline.executeGraphNonBlocking();
-    cudaStreamSynchronize(0);
+    pipeline.executeFrame();
     auto end = std::chrono::high_resolution_clock::now();
     
     auto latency = std::chrono::duration<float, std::milli>(end - start).count();


### PR DESCRIPTION
## Summary
- drop the frame statistics bookkeeping and wait helpers so the main loop simply blocks on synchronous frame execution
- replace the non-blocking graph launch with a single executeFrame path that synchronizes the CUDA stream and reuses the same dispatch logic for graph and non-graph runs
- refresh the documentation snippets to reference executeFrame now that the pipeline no longer exposes executeGraphNonBlocking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ced3f0923c8325be37cd77a9bce374