### PR TITLE
Remove unused code and comments

### DIFF
--- a/HID_Arduino/restore_arduino.py
+++ b/HID_Arduino/restore_arduino.py
@@ -2,6 +2,7 @@ import os
 import stat
 import ctypes
 import sys
+import re
 
 def is_admin():
     try:
@@ -73,7 +74,6 @@ for i, line in enumerate(lines):
         new_lines.append(f'leonardo.build.usb_manufacturer="{default_manufacturer}"\n')
     elif line.startswith("leonardo.build.extra_flags="):
         # COM 포트 활성화 (CDC_DISABLED 제거)
-        import re
         new_line = re.sub(r"\s*-DCDC_DISABLED", "", line)
         new_lines.append(new_line)
     else:

--- a/HID_Arduino/spoof.py
+++ b/HID_Arduino/spoof.py
@@ -2,7 +2,6 @@ import hid
 import os
 import stat
 import time
-import os
 import re
 import ctypes
 import sys

--- a/needaimbot/AppContext.h
+++ b/needaimbot/AppContext.h
@@ -115,10 +115,6 @@ public:
 
     // CUDA Graph optimization
     std::atomic<bool> use_cuda_graph{false};
-    
-    // Modules
-    // MouseThread removed - GPU handles mouse control directly
-    // Detector removed - TensorRT is now integrated into UnifiedGraphPipeline
 
     // Overlay Target Data
     

--- a/needaimbot/config/config.cpp
+++ b/needaimbot/config/config.cpp
@@ -91,10 +91,7 @@ bool Config::loadConfig(const std::string& filename)
         enable_aim_shoot_offset = false;
         aim_shoot_offset_x = 0.0f;
         aim_shoot_offset_y = 0.0f;
-        
-        // Target lock removed
 
-        
         easynorecoil = false;
         easynorecoilstrength = 0.0f;
         
@@ -133,10 +130,9 @@ bool Config::loadConfig(const std::string& filename)
         
         bScope_multiplier = 1.0f;
 
-        
+
         ai_model = "sunxds_0.5.6.engine";
         confidence_threshold = 0.25f;  // Higher threshold = fewer detections = better performance
-        // NMS removed - no longer needed
         max_detections = 30;  // Reduced from 100 for better performance
         postprocess = "yolo11";  // Changed from yolo12 to match common model format
 
@@ -268,8 +264,6 @@ bool Config::loadConfig(const std::string& filename)
     enable_aim_shoot_offset = get_bool_ini("Target", "enable_aim_shoot_offset", false);
     aim_shoot_offset_x = static_cast<float>(get_double_ini("Target", "aim_shoot_offset_x", 0.0));
     aim_shoot_offset_y = static_cast<float>(get_double_ini("Target", "aim_shoot_offset_y", 0.0));
-    
-    // Target lock removed
 
     easynorecoil = get_bool_ini("Mouse", "easynorecoil", false);
     easynorecoilstrength = static_cast<float>(get_double_ini("Mouse", "easynorecoilstrength", 0.0));
@@ -311,7 +305,6 @@ bool Config::loadConfig(const std::string& filename)
 
     ai_model = get_string_ini("AI", "ai_model", "sunxds_0.5.6.engine");
     confidence_threshold = static_cast<float>(get_double_ini("AI", "confidence_threshold", 0.25));
-    // NMS removed - no longer needed
     max_detections = get_long_ini("AI", "max_detections", 30);
     postprocess = get_string_ini("AI", "postprocess", "yolo11");  // Changed default from yolo12 to yolo11
 
@@ -536,7 +529,6 @@ bool Config::saveConfig(const std::string& filename)
     file << "ai_model = " << ai_model << "\n";
     file << std::fixed << std::setprecision(6);
     file << "confidence_threshold = " << confidence_threshold << "\n";
-    // NMS removed - no longer saved
     file << std::noboolalpha;
     file << "max_detections = " << max_detections << "\n";
     file << "postprocess = " << postprocess << "\n\n";

--- a/needaimbot/config/config.h
+++ b/needaimbot/config/config.h
@@ -105,10 +105,7 @@ public:
     bool enable_aim_shoot_offset;
     float aim_shoot_offset_x;
     float aim_shoot_offset_y;
-    
-    // Target lock feature removed
 
-    
     bool easynorecoil;
     float easynorecoilstrength;
     std::string input_method; 
@@ -149,10 +146,9 @@ public:
     
     float bScope_multiplier;
 
-    
+
     std::string ai_model;
     float confidence_threshold;
-    // NMS removed - no longer needed
     int max_detections;
     std::string postprocess;
 

--- a/needaimbot/needaimbot.cpp
+++ b/needaimbot/needaimbot.cpp
@@ -1,7 +1,5 @@
 #include "core/windows_headers.h"
 #include <timeapi.h>
-
-// OpenCV removed - using custom CUDA image processing
 #include <iostream>
 #include <thread>
 #include <atomic>
@@ -47,8 +45,6 @@
 #include <string_view>
 #include <memory>
 #include <filesystem>
-
-// #include "mouse/aimbot_components/AimbotTarget.h" - Removed, using core/Target.h
 #include <algorithm>
 
 // Global variable definitions
@@ -355,8 +351,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 }
 #endif
 
-// Administrator privilege check removed - not required for normal operation
-
 // Crash dump handler
 LONG WINAPI UnhandledExceptionHandler(EXCEPTION_POINTERS* pExceptionPointers) {
     std::cerr << "\n[CRASH] Unhandled exception occurred!" << std::endl;
@@ -466,10 +460,7 @@ int main()
     
     // Try to set high priority (doesn't require admin)
     SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
-    
-    
-    // Process priority removed for better system stability
-    
+
     // Set application title
     SetConsoleTitle(L"Gaming Performance Analyzer - Monitor & Optimize Gaming Performance");
     
@@ -578,7 +569,6 @@ int main()
             return -1;
         }
 
-        // MouseThread removed - GPU handles mouse control directly
         // Initialize InputMethod for recoil control only
         (void)initializeInputMethod();
 
@@ -654,14 +644,10 @@ int main()
             combinedUIThread,
             numCores > 2 ? 1 : -1,
             ThreadManager::Priority::ABOVE_NORMAL);
-        
-        // Mouse thread removed - GPU handles mouse control directly
-        // ThreadManager mouseThreadMgr removed
-        
+
         // Start all threads
         pipelineThreadMgr.start();
         uiThreadMgr.start();
-        // mouseThreadMgr.start(); - removed, GPU handles mouse directly
 
         welcome_message();
         

--- a/needaimbot/overlay/draw_ai.cpp
+++ b/needaimbot/overlay/draw_ai.cpp
@@ -115,17 +115,15 @@ static void draw_detection_settings()
         SAVE_PROFILE();
         ctx.model_changed = true;
     }
-    
+
     UIHelpers::Spacer();
-    
-    if (UIHelpers::EnhancedSliderFloat("Confidence Threshold", &ctx.config.confidence_threshold, 0.01f, 1.00f, "%.2f", 
+
+    if (UIHelpers::EnhancedSliderFloat("Confidence Threshold", &ctx.config.confidence_threshold, 0.01f, 1.00f, "%.2f",
                                       "Minimum confidence score required for target detection. Higher values = fewer false positives."))
     {
         SAVE_PROFILE();
     }
-    
-    // NMS removed - no longer needed
-    
+
     // Max detections slider with better styling
     ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.18f, 0.95f));
     ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.20f, 0.20f, 0.25f, 1.0f));
@@ -203,14 +201,12 @@ static void draw_class_settings()
             ImGui::TableSetColumnIndex(2);
             if (ImGui::Checkbox("##Allow", &setting.allow)) {
                 SAVE_PROFILE();
-                // TODO: Implement flag update for TensorRT integration
             }
 
             ImGui::TableSetColumnIndex(3);
             if (UIHelpers::BeautifulButton("Remove", ImVec2(-1, 0))) {
                 ctx.config.class_settings.erase(ctx.config.class_settings.begin() + i);
                 SAVE_PROFILE();
-                // TODO: Implement flag update for TensorRT integration
                 ImGui::PopID(); 
                 i--; 
                 continue; 
@@ -266,8 +262,7 @@ static void draw_class_settings()
         if (!id_exists && !temp_name.empty()) {
             ctx.config.class_settings.emplace_back(new_class_id, temp_name, new_class_allow);
             SAVE_PROFILE();
-            // TODO: Implement flag update for TensorRT integration
-            
+
             new_class_id = CommonHelpers::getNextClassId();
             new_class_name_buf[0] = '\0'; 
             new_class_allow = true;
@@ -280,12 +275,11 @@ static void draw_class_settings()
 static void draw_advanced_settings()
 {
     auto& ctx = AppContext::getInstance();
-    
-    static bool advanced_open = true;  // 기본적으로 열려있게 변경
+
+    static bool advanced_open = true;
     UIHelpers::BeginCard("Advanced Settings");
-    
-    // CollapsingHeader 대신 항상 표시되도록 변경 (디버깅용)
-    if (true) {  // if (ImGui::CollapsingHeader("Advanced Settings", &advanced_open)) {
+
+    if (true) {
         UIHelpers::CompactSpacer();
         
         ImGui::PushItemWidth(-1);
@@ -318,7 +312,6 @@ static void draw_advanced_settings()
         
         if (ImGui::Checkbox("Use CUDA Graph", &ctx.config.use_cuda_graph)) {
             SAVE_PROFILE();
-            // Graph 모드 변경 시 재빌드 필요
             auto& pipelineManager = needaimbot::PipelineManager::getInstance();
             if (pipelineManager.getPipeline()) {
                 pipelineManager.getPipeline()->setGraphRebuildNeeded();

--- a/needaimbot/overlay/draw_debug.cpp
+++ b/needaimbot/overlay/draw_debug.cpp
@@ -8,14 +8,12 @@
 #include <vector>
 #include <string>
 #include <d3d11.h>
-// #include "../capture/capture.h" - removed, using GPU capture now
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <iostream>
 #include <algorithm>
 #include <cstring>
-// OpenCV removed - using custom CUDA utilities
 #include "../cuda/simple_cuda_mat.h"
 
 
@@ -137,11 +135,6 @@ void uploadDebugFrame(const SimpleMat& rgbaCpu)
 
     g_pd3dDeviceContext->Unmap(g_debugTex, 0);
 }
-
-
-
-
-// uploadColorMaskTexture removed
 
 void drawDetections(ImDrawList* draw_list, ImVec2 image_pos, float debug_scale, const std::vector<Target>* targets_override) {
     auto& ctx = AppContext::getInstance();

--- a/needaimbot/overlay/draw_profile.cpp
+++ b/needaimbot/overlay/draw_profile.cpp
@@ -104,12 +104,6 @@ void draw_profile()
                     status_message = "[OK] Saved settings to: " + profile_list[n];
                     status_time = std::chrono::steady_clock::now();
                 }
-                if (ImGui::MenuItem("Rename...")) {
-                    // TODO: Implement rename
-                }
-                if (ImGui::MenuItem("Duplicate")) {
-                    // TODO: Implement duplicate
-                }
                 ImGui::Separator();
                 if (profile_list[n] != "Default" && ImGui::MenuItem("Delete")) {
                     show_confirm_delete = true;
@@ -225,23 +219,6 @@ void draw_profile()
         }
     }
     
-    
-    UIHelpers::Spacer();
-    UIHelpers::BeautifulSeparator("Profile Actions");
-    UIHelpers::CompactSpacer();
-    
-    // Export/Import buttons
-    if (UIHelpers::BeautifulButton("Export Profile", ImVec2(ImGui::GetContentRegionAvail().x * 0.48f, 0))) {
-        // TODO: Implement export
-        status_message = "[INFO] Export feature coming soon";
-        status_time = std::chrono::steady_clock::now();
-    }
-    ImGui::SameLine();
-    if (UIHelpers::BeautifulButton("Import Profile", ImVec2(-1, 0))) {
-        // TODO: Implement import
-        status_message = "[INFO] Import feature coming soon";
-        status_time = std::chrono::steady_clock::now();
-    }
     
     UIHelpers::EndCard();
     


### PR DESCRIPTION
Removed obsolete comments and cleaned up code across the codebase:
- Removed comments referencing removed features (MouseThread, OpenCV, NMS, Target lock)
- Fixed duplicate import in spoof.py
- Moved import re to top of restore_arduino.py
- Removed TODO comments for unimplemented features
- Removed Korean debug comments and replaced with clean code
- Total: 82 lines removed, improving code readability

Changes made:
- needaimbot.cpp: Removed 7 obsolete comment blocks
- draw_ai.cpp: Removed 6 TODO/debug comments
- draw_debug.cpp: Removed 3 obsolete comments
- draw_profile.cpp: Removed unused menu items and export/import placeholders
- config.cpp/h: Removed 7 obsolete feature reference comments
- AppContext.h: Removed obsolete module comments
- spoof.py: Fixed duplicate os import
- restore_arduino.py: Moved import to top level