### PR TITLE
Fix build error: Add auto_shoot and ignore_up_aim to Config

### DIFF
--- a/needaimbot/config/config.cpp
+++ b/needaimbot/config/config.cpp
@@ -72,8 +72,10 @@ bool Config::loadConfig(const std::string& filename)
         body_y_offset = 0.15f;
         head_y_offset = 0.05f;
         offset_step = 0.01f;
-        
+
         auto_aim = false;
+        auto_shoot = false;
+        ignore_up_aim = false;
 
 
         crosshair_offset_x = 0.0f;
@@ -254,8 +256,10 @@ bool Config::loadConfig(const std::string& filename)
     offset_step = static_cast<float>(get_double_ini("Target", "offset_step", 0.01));
     
     // Batch load booleans
-    
+
     auto_aim = get_bool_ini("Target", "auto_aim", false);
+    auto_shoot = get_bool_ini("Target", "auto_shoot", false);
+    ignore_up_aim = get_bool_ini("Target", "ignore_up_aim", false);
 
     crosshair_offset_x = static_cast<float>(get_double_ini("Target", "crosshair_offset_x", 0.0));
     crosshair_offset_y = static_cast<float>(get_double_ini("Target", "crosshair_offset_y", 0.0));
@@ -468,13 +472,13 @@ bool Config::saveConfig(const std::string& filename)
     file << "offset_step = " << offset_step << "\n";
     file << "crosshair_offset_x = " << crosshair_offset_x << "\n";
     file << "crosshair_offset_y = " << crosshair_offset_y << "\n";
+    file << "auto_aim = " << (auto_aim ? "true" : "false") << "\n";
+    file << "auto_shoot = " << (auto_shoot ? "true" : "false") << "\n";
+    file << "ignore_up_aim = " << (ignore_up_aim ? "true" : "false") << "\n";
     file << "enable_aim_shoot_offset = " << (enable_aim_shoot_offset ? "true" : "false") << "\n";
     file << "aim_shoot_offset_x = " << aim_shoot_offset_x << "\n";
     file << "aim_shoot_offset_y = " << aim_shoot_offset_y << "\n";
-    // enable_target_lock removed
     file << std::noboolalpha;
-    
-    file << "auto_aim = " << (auto_aim ? "true" : "false") << "\n";
     file << "\n";
 
 

--- a/needaimbot/config/config.h
+++ b/needaimbot/config/config.h
@@ -93,11 +93,13 @@ public:
 
     float body_y_offset;
     float head_y_offset;
-    float offset_step;  
-    
-    bool auto_aim;
+    float offset_step;
 
-    
+    bool auto_aim;
+    bool auto_shoot;
+    bool ignore_up_aim;
+
+
     float crosshair_offset_x;
     float crosshair_offset_y;
     


### PR DESCRIPTION
Added missing config fields that were used in draw_target.cpp but not defined in Config struct:
- auto_shoot: Enable automatic shooting when target is locked
- ignore_up_aim: Prevent upward aim movement

Changes:
- config.h: Added bool auto_shoot and bool ignore_up_aim fields
- config.cpp: Added initialization, loading, and saving for new fields
- Removed duplicate auto_aim save statement