### PR TITLE
Refactor: Simplify pipeline to synchronous execution

### DIFF
--- a/needaimbot/cuda/unified_graph_pipeline.h
+++ b/needaimbot/cuda/unified_graph_pipeline.h
@@ -500,7 +500,6 @@ private:
     // Performance tracking
     PerformanceMetrics m_perfMetrics;
 
-    std::atomic<bool> m_allowMovement{false};
     std::atomic<bool> m_shouldStop{false};
     std::atomic<bool> m_frameInFlight{false};
     // Signal when a frame-in-flight completes to avoid active yielding
@@ -562,9 +561,6 @@ private:
     MouseMovement filterMouseMovement(const MouseMovement& rawMovement, bool movementEnabled);
     void clearHostPreviewData(AppContext& ctx);
     void handleAimbotActivation();
-
-    bool enqueueFrameCompletionCallback(cudaStream_t stream);
-    bool enqueueMovementResetCallback(cudaStream_t stream);
 
     bool updateDDACaptureRegion(const AppContext& ctx);
     bool performFrameCapture();


### PR DESCRIPTION
Major changes:
1. executeFrame now runs synchronously - waits for CUDA stream completion
2. Mouse movement processing moved from async callbacks to synchronous execution
3. Removed unnecessary async infrastructure:
   - enqueueFrameCompletionCallback()
   - enqueueMovementResetCallback()
   - m_allowMovement flag
4. Removed callbacks from CUDA graph capture
5. Simplified runMainLoop - no need to wait after executeFrame anymore

Benefits:
- 100 lines of code removed (158 deleted, 58 added)
- Much simpler control flow - easier to understand and maintain
- No race conditions between async callbacks
- Fixes oscillation issue - each frame completes before next one starts
- Single shot and main loop now behave identically

Technical details:
- Added cudaStreamSynchronize() in executeFrame before mouse processing
- Mouse movement logic extracted from callback into executeFrame
- m_frameInFlight still used for GPU_BUSY detection
- CUDA graph execution itself is still async, but we wait before next frame